### PR TITLE
Fixed-Layout Display Issues Fixed

### DIFF
--- a/src/navigator/rendition.ts
+++ b/src/navigator/rendition.ts
@@ -61,8 +61,13 @@ export class Rendition {
     const minColWidth = this.vs.getSettingWithDefaultValue<number>(SettingName.MinColumnWidth, 400);
     const colGap = this.vs.getSettingWithDefaultValue<number>(SettingName.ColumnGap, 0);
 
-    const maxPageWidth = maxColWidth + colGap;
     const minPageWidth = minColWidth + colGap;
+    let maxPageWidth;
+    if (this.pub.metadata.rendition && this.pub.metadata.rendition.layout === 'fixed') {
+      maxPageWidth = Number.MAX_SAFE_INTEGER;
+    } else {
+      maxPageWidth = maxColWidth + colGap;
+    }
 
     let numOfPagesPerSpread: number = 1;
     if (spreadMode === SpreadMode.Freeform) {

--- a/src/navigator/views/layout-view.ts
+++ b/src/navigator/views/layout-view.ts
@@ -167,6 +167,10 @@ export class LayoutView extends View {
     }
   }
 
+  public getPageWidth(): number {
+    return this.pageWidth;
+  }
+
   public setNumberOfPagesPerSpread(num: number): void {
     this.numOfPagesPerSpread = num;
   }

--- a/src/navigator/views/layout-view.ts
+++ b/src/navigator/views/layout-view.ts
@@ -476,14 +476,15 @@ export class LayoutView extends View {
     this.layoutRoot.style.overflow = 'hidden';
   }
 
-  public visiblePages(start: number, end: number): [[number, number], number][] {
+  public pageSizes(start: number, numOfPages: number): [[number, number], number][] {
     const pageRanges: [[number, number], number][] = [];
     for (const vs of this.spineItemViewStatus) {
+      if (pageRanges.length >= numOfPages) {
+        break;
+      }
+
       if (vs.offset + vs.viewSize < start) {
         continue;
-      }
-      if (vs.offset > end) {
-        break;
       }
 
       const pageCount = vs.view.getTotalPageCount();
@@ -493,9 +494,12 @@ export class LayoutView extends View {
       for (let i = 0; i < pageCount; i = i + 1) {
         const pageStart = vs.offset + i * pageSize;
         const pageEnd = pageStart + pageSize;
-        if (pageStart >= start && pageStart <= end &&
-            pageEnd >= start && pageEnd <= end) {
+        if (pageStart >= start) {
           pageRanges.push([[pageStart, pageEnd], pageHeight]);
+        }
+
+        if (pageRanges.length >= numOfPages) {
+          break;
         }
       }
     }

--- a/src/navigator/views/layout-view.ts
+++ b/src/navigator/views/layout-view.ts
@@ -476,8 +476,8 @@ export class LayoutView extends View {
     this.layoutRoot.style.overflow = 'hidden';
   }
 
-  public visiblePages(start: number, end: number): [number, number][] {
-    const pageRanges: [number, number][] = [];
+  public visiblePages(start: number, end: number): [[number, number], number][] {
+    const pageRanges: [[number, number], number][] = [];
     for (const vs of this.spineItemViewStatus) {
       if (vs.offset + vs.viewSize < start) {
         continue;
@@ -489,12 +489,13 @@ export class LayoutView extends View {
       const pageCount = vs.view.getTotalPageCount();
       const pageSize = vs.view.fixedLayout() ? this.spineItemViewSizes[vs.spineItemIndex] :
                                                vs.view.getPageSize(this.pageWidth);
-      for (let i = 1; i <= pageCount; i = i + 1) {
-        const pageStart = vs.offset + (i - 1) * pageSize;
+      const pageHeight = vs.view.getPageHeight(this.pageHeight);
+      for (let i = 0; i < pageCount; i = i + 1) {
+        const pageStart = vs.offset + i * pageSize;
         const pageEnd = pageStart + pageSize;
         if (pageStart >= start && pageStart <= end &&
             pageEnd >= start && pageEnd <= end) {
-          pageRanges.push([pageStart, pageEnd]);
+          pageRanges.push([[pageStart, pageEnd], pageHeight]);
         }
       }
     }

--- a/src/navigator/views/spine-item-view.ts
+++ b/src/navigator/views/spine-item-view.ts
@@ -224,6 +224,18 @@ export class SpineItemView extends View {
     return pageWidth;
   }
 
+  public getPageHeight(pageHeight: number): number {
+    if (this.isFixedLayout) {
+      return this.contentView.metaHeight() * this.scale;
+    }
+
+    if (this.isVertical) {
+      return this.contentHeight;
+    }
+
+    return pageHeight;
+  }
+
   public getCfi(offsetMain: number, offset2nd: number, backward: boolean): string {
     if (this.contentStatus !== ContentLoadingStatus.Loaded) {
       return '';

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -101,7 +101,7 @@ export class Viewport {
         this.root.style.height = `${this.viewportSize}px`;
       } else {
         this.root.style.width = `${this.visibleViewportSize}px`;
-        this.root.style.height = `${this.viewportSize2nd * this.bookView.getZoomScale()}px`;
+        this.root.style.height = `${this.viewportSize2nd}px`;
       }
 
       this.contentContainer.style.width = this.root.style.width;

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -556,15 +556,14 @@ export class Viewport {
       return start;
     }
 
-    let actualStart = start;
-    const doublepageSpreadLayout = this.bookView.arrangeDoublepageSpreads(start);
+    let pagesBefore = 0;
+    const doublepageSpreadLayout = this.bookView.arrangeDoublepageSpreads(Math.ceil(start));
     if (numOfPagePerSpread === 2) {
       this.clipContatiner.style.position = 'absolute';
       if (doublepageSpreadLayout) {
         if (doublepageSpreadLayout === 'right') {
-          // start/end is shifted one page left if current page is marked 'right'
-          const pageWidth = this.bookView.getPageWidth();
-          actualStart -= pageWidth;
+          // start is shifted one page left if current page is marked 'right'
+          pagesBefore = numOfPagePerSpread - 1;
         } else if (doublepageSpreadLayout === 'center') {
           this.clipContatiner.style.position = '';
           this.clipContatiner.style.margin = 'auto';
@@ -572,8 +571,7 @@ export class Viewport {
       }
     }
 
-    actualStart -= 1; // avoid rounding errors
-    const pageRanges = this.bookView.pageSizes(actualStart, numOfPagePerSpread);
+    const pageRanges = this.bookView.pageSizes(Math.floor(start), numOfPagePerSpread - pagesBefore, pagesBefore);
     if (pageRanges.length < numOfPagePerSpread && doublepageSpreadLayout === 'right') {
       // this can happen on first page, when it is marked right
       let clipperLeft = Math.max(0, this.root.offsetWidth - this.bookView.getPageWidth() * 2);

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -596,6 +596,9 @@ export class Viewport {
     this.clipContatiner.style.width = `${this.visibleViewportSize}px`;
     this.clipContatiner.style.height = `${this.viewportSize2nd * this.bookView.getZoomScale()}px`;
 
+    const clipperLeft = Math.max(0, this.root.offsetWidth - this.visibleViewportSize);
+    this.clipContatiner.style.left = `${clipperLeft / 2}px`;
+
     return firstPage[0];
   }
 

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -277,7 +277,7 @@ export class Viewport {
   }
 
   public async prevScreen(token?: CancellationToken): Promise<void> {
-    let newPos = this.viewOffset - this.getScaledViewportSize();
+    let newPos = this.viewOffset - this.visibleViewportSize;
     const loadedStartPos = this.bookView.getLoadedStartPostion();
     // Ensure not to go beyond begining of the book
     if (newPos < loadedStartPos && !this.bookView.hasMoreBeforeStart()) {

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -602,7 +602,6 @@ export class Viewport {
     }
     this.visibleViewportSize = lastPage[1] - firstPage[0];
     this.clipContatiner.style.width = `${this.visibleViewportSize}px`;
-    this.clipContatiner.style.height = `${Math.max(firstPage[2], lastPage[2])}px`;
 
     // center viewport clipper
     const clipperRight = this.root.offsetWidth - this.visibleViewportSize;
@@ -612,6 +611,13 @@ export class Viewport {
     } else {
       this.clipContatiner.style.right = `${clipperRight / 2}px`;
     }
+
+    let clipperHeight = Math.max(firstPage[2], lastPage[2]);
+    if (clipperHeight === 0) {
+      // first/last page height hasn't loaded or not set yet
+      clipperHeight = this.clipContatiner.scrollHeight;
+    }
+    this.clipContatiner.style.height = `${clipperHeight}px`;
 
     return firstPage[0];
   }

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -516,7 +516,7 @@ export class Viewport {
 
     let newPos = pos;
     if (this.scrollMode === ScrollMode.None) {
-      newPos = this.clipToVisibleRange(pos, pos + this.getScaledViewportSize());
+      newPos = this.clipToVisibleRange(pos);
     }
 
     this.updatePositions();
@@ -550,14 +550,13 @@ export class Viewport {
     this.bookView.showOnlySpineItemRange(this.startPos.spineItemIndex);
   }
 
-  private clipToVisibleRange(start: number, end: number): number {
+  private clipToVisibleRange(start: number): number {
     const numOfPagePerSpread = this.bookView.numberOfPagesPerSpread();
     if (numOfPagePerSpread < 1) {
       return start;
     }
 
     let actualStart = start;
-    let actualEnd = end;
     const doublepageSpreadLayout = this.bookView.arrangeDoublepageSpreads(start);
     if (numOfPagePerSpread === 2) {
       this.clipContatiner.style.position = 'absolute';
@@ -566,7 +565,6 @@ export class Viewport {
           // start/end is shifted one page left if current page is marked 'right'
           const pageWidth = this.bookView.getPageWidth();
           actualStart -= pageWidth;
-          actualEnd -= pageWidth;
         } else if (doublepageSpreadLayout === 'center') {
           this.clipContatiner.style.position = '';
           this.clipContatiner.style.margin = 'auto';
@@ -575,8 +573,7 @@ export class Viewport {
     }
 
     actualStart -= 1; // avoid rounding errors
-    actualEnd += 1; // avoid rounding errors
-    const pageRanges = this.bookView.visiblePages(actualStart, actualEnd);
+    const pageRanges = this.bookView.pageSizes(actualStart, numOfPagePerSpread);
     if (pageRanges.length < numOfPagePerSpread && doublepageSpreadLayout === 'right') {
       // this can happen on first page, when it is marked right
       let clipperLeft = Math.max(0, this.root.offsetWidth - this.bookView.getPageWidth() * 2);

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -67,8 +67,8 @@ export class Viewport {
   }
 
   public setScrollMode(mode: ScrollMode): void {
-    this.root.style.overflowX = 'hidden';
-    this.root.style.overflowY = 'hidden';
+    this.root.style.overflowX = 'auto';
+    this.root.style.overflowY = 'auto';
     // tslint:disable-next-line:no-any
     (<any>this.root.style).webkitOverflowScrolling = 'auto';
 
@@ -587,11 +587,11 @@ export class Viewport {
       this.clipContatiner.style.left = '';
     }
 
-    pageRanges.sort((page1: [number, number], page2: [number, number]) => {
-      const page1Dist = Math.min(Math.abs(this.viewOffset - page1[0]),
-                                 Math.abs(this.viewOffset - page1[1]));
-      const page2Dist = Math.min(Math.abs(this.viewOffset - page2[0]),
-                                 Math.abs(this.viewOffset - page2[1]));
+    pageRanges.sort((page1: [[number, number], number], page2: [[number, number], number]) => {
+      const page1Dist = Math.min(Math.abs(this.viewOffset - page1[0][0]),
+                                 Math.abs(this.viewOffset - page1[0][1]));
+      const page2Dist = Math.min(Math.abs(this.viewOffset - page2[0][0]),
+                                 Math.abs(this.viewOffset - page2[0][1]));
 
       return page1Dist - page2Dist;
     });
@@ -600,12 +600,12 @@ export class Viewport {
 
     let firstPage = spreadPages[0];
     let lastPage = spreadPages[spreadPages.length - 1];
-    if (lastPage[0] < firstPage[0]) {
+    if (lastPage[0][0] < firstPage[0][0]) {
       [firstPage, lastPage] = [lastPage, firstPage];
     }
-    this.visibleViewportSize = lastPage[1] - firstPage[0];
+    this.visibleViewportSize = lastPage[0][1] - firstPage[0][0];
     this.clipContatiner.style.width = `${this.visibleViewportSize}px`;
-    this.clipContatiner.style.height = `${this.viewportSize2nd * this.bookView.getZoomScale()}px`;
+    this.clipContatiner.style.height = `${Math.max(firstPage[1], lastPage[1])}px`;
 
     // center viewport clipper
     const clipperRight = this.root.offsetWidth - this.visibleViewportSize;
@@ -616,7 +616,7 @@ export class Viewport {
       this.clipContatiner.style.right = `${clipperRight / 2}px`;
     }
 
-    return firstPage[0];
+    return firstPage[0][0];
   }
 
   private getScaledViewportSize(): number {

--- a/test/specs/navigator.spec.ts
+++ b/test/specs/navigator.spec.ts
@@ -132,6 +132,42 @@ describe('Navigator', () => {
       await initBook('/fixtures/publications/igp-twss-fxl/manifest.json', true, false);
     });
 
+    it('GoToRightPageDoublePageSpread', async () => {
+      const rendition = hostEnv.getRendition();
+      rendition.viewport.setPrefetchSize(100);
+      rendition.setPageLayout({ spreadMode: SpreadMode.FitViewportDoubleSpread });
+
+      const rightPageLocation = new Location('', 'OPS/s011-Poem-001.xhtml');
+      await navigator.gotoLocation(rightPageLocation);
+
+      const loc = await navigator.getScreenBegin();
+      assert(loc);
+      assert.equal(loc!.getHref(), 'OPS/s010-Section-004.xhtml');
+
+      const endLoc = await navigator.getScreenEnd();
+      assert(endLoc);
+      assert.equal(endLoc!.getHref(), rightPageLocation.getHref());
+    });
+
+    it('GoToFirstPageDoublePageSpread', async () => {
+      // first page marked right by default unless explicitly defined
+
+      const rendition = hostEnv.getRendition();
+      rendition.viewport.setPrefetchSize(100);
+      rendition.setPageLayout({ spreadMode: SpreadMode.FitViewportDoubleSpread });
+
+      const rightPageLocation = new Location('', 'OPS/s001-Cover-01.xhtml');
+      await navigator.gotoLocation(rightPageLocation);
+
+      const loc = await navigator.getScreenBegin();
+      assert(loc);
+      assert.equal(loc!.getHref(), rightPageLocation.getHref());
+
+      const endLoc = await navigator.getScreenEnd();
+      assert(endLoc);
+      assert.equal(endLoc!.getHref(), rightPageLocation.getHref());
+    });
+
     it('nextScreen()', async () => {
       await navigator.nextScreen();
       await navigator.nextScreen();


### PR DESCRIPTION
Fixed various problems with display and manipulating display of fixed layout epubs including:

- Switching from double page spread to single page spread on a page with property "rendition:page-spread-right"

- Aligning pages to center of screen/viewport

- Aligning a single page to left or right depending on it's rendition property (page-spread-[left/right])

- Allow scaling to page width > 700

- Enable scrolling

Other fixes
- Calling setZoom also re-renders the page so that the pages are properly aligned after the zoom.