### PR TITLE
Ensure callbacks are added to spine item on reload

### DIFF
--- a/src/navigator/views/layout-view.ts
+++ b/src/navigator/views/layout-view.ts
@@ -764,6 +764,9 @@ export class LayoutView extends View {
       spineItemView.setTotalPageCount(this.spineItemViewPageCounts[index]);
       spineItemView.loadSpineItem(this.publication.spine[index], this.vs, token).then(() => {
         this.onSpineItemLoaded(spineItemView);
+        spineItemView.onSelfResize(() => {
+          this.rePaginate();
+        });
       });
     } else {
       this.hasUnknownSizeSpineItemLoading = true;


### PR DESCRIPTION
When the spine item is loaded it creates a new content view which does
not have any of the callbacks that were applied to it on the last load.